### PR TITLE
First version ready for service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     }
   ],
   "require": {
-    "rhubarbphp/rhubarb": "dev-crown",
-    "rhubarbphp/module-stem": "dev-migration"
+    "rhubarbphp/rhubarb": ">=0.9",
+    "rhubarbphp/module-stem": ">=0.9"
   },
   "require-dev": {
     "phpunit/phpunit": "3.*"

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ own @property definitions on the doc comment to give your IDE some idea of what 
 support.
 
 The key difference with this settings object is that settings are persisted in a repository through the
-`ApplicationSetting` model (not singular not plural).
+`ApplicationSetting` model (note singular not plural).
 
 You should not use the `ApplicationSetting` model directly; always use the `ApplicationSettings` class.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,41 @@
+Application Settings
+====================
+
+This scaffold brings a modified settings object to your project called `ApplicationSettings`. You can either
+use the class directly, however like all setting objects it's best if you extend the class and provide your
+own @property definitions on the doc comment to give your IDE some idea of what settings you're looking to
+support.
+
+The key difference with this settings object is that settings are persisted in a repository through the
+`ApplicationSetting` model (not singular not plural).
+
+You should not use the `ApplicationSetting` model directly; always use the `ApplicationSettings` class.
+
+Only use ApplicationSettings for settings that can be changed by users in the interface. All other 'static'
+settings should be contained in normal setting objects.
+
+~~~ php
+$settings = new ApplicationSettings();
+$settings->GlobalBounceEmail = "postmaster@widgets.com"
+~~~
+
+~~~ php
+$settings = new ApplicationSettings();
+
+if ( $settings->InFireSale )
+{
+    dropPrices();
+}
+~~~
+
+Defining your own extension of the class:
+
+~~~ php
+
+/**
+ * @property string $CurrentRealexToken The token needed to use the realex API
+ * @property string $PanicEmailAdddress The email address we're sending panic emails to
+ */
+class MyApplicationSettings extends ApplicationSettings
+{
+}

--- a/src/ApplicationSettingModule.php
+++ b/src/ApplicationSettingModule.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ *	Copyright 2015 RhubarbPHP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace Rhubarb\Scaffolds\ApplicationSettings;
+
+use Rhubarb\Crown\Module;
+use Rhubarb\Stem\Schema\SolutionSchema;
+
+class ApplicationSettingModule extends Module
+{
+    protected function initialise()
+    {
+        parent::initialise();
+
+        SolutionSchema::registerSchema( "ApplicationSettings", __NAMESPACE__."\\Models\\ApplicationSettingsSolutionSchema");
+    }
+}

--- a/src/Models/ApplicationSetting.php
+++ b/src/Models/ApplicationSetting.php
@@ -18,6 +18,8 @@
 
 namespace Rhubarb\Scaffolds\ApplicationSettings\Models;
 
+use Rhubarb\Stem\Exceptions\RecordNotFoundException;
+use Rhubarb\Stem\Filters\Equals;
 use Rhubarb\Stem\Models\Model;
 use Rhubarb\Stem\Repositories\MySql\Schema\Columns\AutoIncrement;
 use Rhubarb\Stem\Repositories\MySql\Schema\Columns\MediumText;
@@ -34,17 +36,46 @@ class ApplicationSetting extends Model
      */
     protected function createSchema()
     {
-        $schema = new MySqlSchema( "tblApplicationSetting" );
+        $schema = new MySqlSchema("tblApplicationSetting");
         $schema->addColumn(
-            new AutoIncrement( "ApplicationSettingID" ),
-            new Varchar( "SettingName", 30 ),
-            new MediumText( "SettingValue" )
+            new AutoIncrement("ApplicationSettingID"),
+            new Varchar("SettingName", 30),
+            new MediumText("SettingValue")
         );
 
-        $schema->addIndex( new Index( "SettingName", Index::UNIQUE, [ "SettingName" ] ) );
+        $schema->addIndex(new Index("SettingName", Index::UNIQUE, ["SettingName"]));
 
         return $schema;
     }
 
+    /**
+     * Finds a setting entry by it's setting name.
+     *
+     * @param $settingName string The name of the setting the fetch.
+     * @return Model
+     * @throws RecordNotFoundException
+     */
+    public static function findBySettingName($settingName)
+    {
+        return self::findLast(new Equals("SettingName", $settingName));
+    }
 
+    /**
+     * Returns the existing entry for a given setting name or creates a new (but unsaved) model if
+     * one could not be found.
+     *
+     * @param string $settingName The name of the setting to find
+     * @return ApplicationSetting|Model
+     */
+    public static function findOrCreateBySettingName($settingName)
+    {
+        try {
+            return self::findBySettingName($settingName);
+        } catch (RecordNotFoundException $er) {
+            $setting = new self();
+            $setting->SettingName = $settingName;
+
+            return $setting;
+        }
+    }
 }

--- a/src/Models/ApplicationSetting.php
+++ b/src/Models/ApplicationSetting.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ *	Copyright 2015 RhubarbPHP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace Rhubarb\Scaffolds\ApplicationSettings\Models;
+
+use Rhubarb\Stem\Models\Model;
+use Rhubarb\Stem\Repositories\MySql\Schema\Columns\AutoIncrement;
+use Rhubarb\Stem\Repositories\MySql\Schema\Columns\MediumText;
+use Rhubarb\Stem\Repositories\MySql\Schema\Columns\Varchar;
+use Rhubarb\Stem\Repositories\MySql\Schema\Index;
+use Rhubarb\Stem\Repositories\MySql\Schema\MySqlSchema;
+
+class ApplicationSetting extends Model
+{
+    /**
+     * Returns the schema for this data object.
+     *
+     * @return \Rhubarb\Stem\Schema\ModelSchema
+     */
+    protected function createSchema()
+    {
+        $schema = new MySqlSchema( "tblApplicationSetting" );
+        $schema->addColumn(
+            new AutoIncrement( "ApplicationSettingID" ),
+            new Varchar( "SettingName", 30 ),
+            new MediumText( "SettingValue" )
+        );
+
+        $schema->addIndex( new Index( "SettingName", Index::UNIQUE, [ "SettingName" ] ) );
+
+        return $schema;
+    }
+
+
+}

--- a/src/Models/ApplicationSettingsSolutionSchema.php
+++ b/src/Models/ApplicationSettingsSolutionSchema.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ *	Copyright 2015 RhubarbPHP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace Rhubarb\Scaffolds\ApplicationSettings\Models;
+
+use Rhubarb\Stem\Schema\SolutionSchema;
+
+class ApplicationSettingsSolutionSchema extends SolutionSchema
+{
+    public function __construct($version = 0.1)
+    {
+        parent::__construct($version);
+
+        $this->addModel("ApplicationSetting", __NAMESPACE__."\\ApplicationSetting");
+    }
+}

--- a/src/Settings/ApplicationSettings.php
+++ b/src/Settings/ApplicationSettings.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ *	Copyright 2015 RhubarbPHP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace Rhubarb\Scaffolds\ApplicationSettings\Settings;
+
+use Rhubarb\Crown\Settings;
+
+class ApplicationSettings extends Settings
+{
+
+}

--- a/src/Settings/ApplicationSettings.php
+++ b/src/Settings/ApplicationSettings.php
@@ -18,9 +18,31 @@
 
 namespace Rhubarb\Scaffolds\ApplicationSettings\Settings;
 
+require_once __DIR__ . '/../Models/ApplicationSetting.php';
+require_once __DIR__ . '/../../../rhubarb/src/Settings.php';
+
 use Rhubarb\Crown\Settings;
+use Rhubarb\Scaffolds\ApplicationSettings\Models\ApplicationSetting;
+use Rhubarb\Stem\Exceptions\RecordNotFoundException;
 
 class ApplicationSettings extends Settings
 {
+    public function __set($propertyName, $value)
+    {
+        parent::__set($propertyName, $value);
 
+        $setting = ApplicationSetting::FindOrCreateBySettingName($propertyName);
+        $setting->SettingValue = $value;
+        $setting->save();
+    }
+
+    public function __get($propertyName)
+    {
+        try {
+            $setting = ApplicationSetting::FindBySettingName($propertyName);
+            return $setting->SettingValue;
+        } catch( RecordNotFoundException $er){
+            return null;
+        }
+    }
 }

--- a/tests/Settings/ApplicationSettingsTest.php
+++ b/tests/Settings/ApplicationSettingsTest.php
@@ -32,13 +32,14 @@ class ApplicationSettingsTest extends RhubarbTestCase
 
         $applicationSetting = ApplicationSetting::findLast();
 
-        $this->assertEquals( 4, $applicationSetting->SettingValue );
-        $this->assertCount( 1, ApplicationSetting::find(), "The setting was not persisted in the repository" );
+        $this->assertEquals(4, $applicationSetting->SettingValue);
+        $this->assertCount(1, ApplicationSetting::find(), "The setting was not persisted in the repository");
 
         $settings = new ApplicationSettings();
         $settings->HappyCustomers = 5;
 
-        $this->assertCount( 1, ApplicationSetting::find(), "Changing a setting should not result in an additional setting in the table." );
+        $this->assertCount(1, ApplicationSetting::find(),
+            "Changing a setting should not result in an additional setting in the table.");
     }
 
     public function testSettingsRetrieve()
@@ -48,10 +49,10 @@ class ApplicationSettingsTest extends RhubarbTestCase
         $settings = new ApplicationSettings();
         $settings->HappyCustomers = 4;
 
-        Settings::deleteSettingNamespace( "Application" );
+        Settings::deleteSettingNamespace("Application");
 
         $settings = new ApplicationSettings();
 
-        $this->assertEquals( 4, $settings->HappyCustomers );
+        $this->assertEquals(4, $settings->HappyCustomers);
     }
 }

--- a/tests/Settings/ApplicationSettingsTest.php
+++ b/tests/Settings/ApplicationSettingsTest.php
@@ -18,6 +18,7 @@
 
 namespace Rhubarb\Scaffolds\ApplicationSettings\Tests\Settings;
 
+use Rhubarb\Crown\Settings;
 use Rhubarb\Crown\Tests\RhubarbTestCase;
 use Rhubarb\Scaffolds\ApplicationSettings\Models\ApplicationSetting;
 use Rhubarb\Scaffolds\ApplicationSettings\Settings\ApplicationSettings;
@@ -30,6 +31,27 @@ class ApplicationSettingsTest extends RhubarbTestCase
         $settings->HappyCustomers = 4;
 
         $applicationSetting = ApplicationSetting::findLast();
+
         $this->assertEquals( 4, $applicationSetting->SettingValue );
+        $this->assertCount( 1, ApplicationSetting::find(), "The setting was not persisted in the repository" );
+
+        $settings = new ApplicationSettings();
+        $settings->HappyCustomers = 5;
+
+        $this->assertCount( 1, ApplicationSetting::find(), "Changing a setting should not result in an additional setting in the table." );
+    }
+
+    public function testSettingsRetrieve()
+    {
+        ApplicationSetting::clearObjectCache();
+
+        $settings = new ApplicationSettings();
+        $settings->HappyCustomers = 4;
+
+        Settings::deleteSettingNamespace( "Application" );
+
+        $settings = new ApplicationSettings();
+
+        $this->assertEquals( 4, $settings->HappyCustomers );
     }
 }

--- a/tests/Settings/ApplicationSettingsTest.php
+++ b/tests/Settings/ApplicationSettingsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ *	Copyright 2015 RhubarbPHP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace Rhubarb\Scaffolds\ApplicationSettings\Tests\Settings;
+
+use Rhubarb\Crown\Tests\RhubarbTestCase;
+use Rhubarb\Scaffolds\ApplicationSettings\Models\ApplicationSetting;
+use Rhubarb\Scaffolds\ApplicationSettings\Settings\ApplicationSettings;
+
+class ApplicationSettingsTest extends RhubarbTestCase
+{
+    public function testSettingsStore()
+    {
+        $settings = new ApplicationSettings();
+        $settings->HappyCustomers = 4;
+
+        $applicationSetting = ApplicationSetting::findLast();
+        $this->assertEquals( 4, $applicationSetting->SettingValue );
+    }
+}


### PR DESCRIPTION
So this scaffold provides a Settings object which is different from normal Setting objects in that it persists settings in a database table.

One future improvement will be to add another setting object which is user specific, although that might in a different scaffold which would take and extend the model to add a UserID (we probably shouldn't require that people have the authentication scaffold in place just to get application settings)
